### PR TITLE
Create Flutter UI for lead level predictor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+.pub-cache/
+build/
+flutter_*.png
+*.lock
+
+# Android specific
+**/android/**/gradle-wrapper.jar
+**/android/.gradle/
+**/android/app/build/
+**/android/local.properties
+
+# iOS/macOS
+**/ios/Pods/
+**/ios/.symlinks/
+**/ios/Flutter/Flutter.framework
+**/ios/Flutter/Flutter.podspec
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
+# Lead Level Predictor
 
-# lead_level_predictor
-App to predict the Blood lead level based on some input params
+A Flutter application that collects household and lifestyle details to estimate a child's blood lead level. The interface is divided into four clear sections that mirror the requested layout:
+
+1. **Input Information** – Three paginated forms with four fields per page capture all required features from the dataset images (age, education, occupation, take home exposure, water source, cosmetic usage, utensils, symptoms, and maternal BLL).
+2. **Results** – Displays the full set of inputs alongside the calculated blood lead level and the derived risk category.
+3. **Suggestions** – Generates prevention tips that adapt to the predicted risk level.
+4. **Lead Toxicity** – A concise article that educates users about exposure sources, warning signs, and prevention tactics.
+
+The prediction logic is implemented in Dart (`lib/services/prediction_service.dart`) as a placeholder scoring system that can be swapped for an actual trained model when available.
+
+## Getting Started
+
+1. Install [Flutter](https://docs.flutter.dev/get-started/install) and ensure that `flutter doctor` passes.
+2. (First-time setup only) Generate the native platform folders by running `flutter create .` in the project root. Existing Dart files will be preserved.
+3. Fetch dependencies:
+   ```bash
+   flutter pub get
+   ```
+4. Run the app on an emulator or device:
+   ```bash
+   flutter run
+   ```
+
+## Project Structure
+
+- `lib/main.dart` – App entry point and theme configuration.
+- `lib/screens/` – UI for each section (input form, results, suggestions, and lead toxicity article).
+- `lib/controllers/` – Simple state management for the collected inputs and prediction results.
+- `lib/models/` – Data classes for the form inputs and prediction output.
+- `lib/services/` – Mock prediction logic and contextual suggestions.
+
+## Replacing the Mock Model
+
+To integrate a real trained model:
+
+1. Expose the model through a Dart/Flutter compatible API (for example, a TensorFlow Lite interpreter or a REST endpoint).
+2. Update `PredictionService.predict` to call the real inference code and convert the response to `PredictionResult`.
+3. Adjust the suggestion thresholds or categories as needed to match the model's output scale.
+
+## Notes
+
+- The current implementation uses dropdown inputs for categorical features to mirror the dataset fields exactly.
+- The suggestion content and lead toxicity article provide general guidance and should be reviewed by subject matter experts before production use.

--- a/lib/controllers/lead_prediction_controller.dart
+++ b/lib/controllers/lead_prediction_controller.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import '../models/lead_input.dart';
+import '../models/prediction_result.dart';
+import '../services/prediction_service.dart';
+
+class LeadPredictionController extends ChangeNotifier {
+  LeadInput input = LeadInput.empty();
+  PredictionResult? _result;
+  bool _hasPredicted = false;
+
+  PredictionResult? get result => _result;
+  bool get hasPredicted => _hasPredicted;
+
+  void updateField(String key, String? value) {
+    input = input.copyWithField(key, value);
+    notifyListeners();
+  }
+
+  void predict() {
+    _result = PredictionService().predict(input);
+    _hasPredicted = true;
+    notifyListeners();
+  }
+
+  void reset() {
+    input = LeadInput.empty();
+    _result = null;
+    _hasPredicted = false;
+    notifyListeners();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'screens/home_screen.dart';
+
+void main() {
+  runApp(const LeadLevelPredictorApp());
+}
+
+class LeadLevelPredictorApp extends StatelessWidget {
+  const LeadLevelPredictorApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Lead Level Predictor',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF4F46E5)),
+        useMaterial3: true,
+        textTheme: const TextTheme(
+          bodyMedium: TextStyle(fontSize: 16),
+        ),
+      ),
+      home: const HomeScreen(),
+    );
+  }
+}

--- a/lib/models/lead_input.dart
+++ b/lib/models/lead_input.dart
@@ -1,0 +1,55 @@
+class LeadInput {
+  final Map<String, String?> values;
+
+  LeadInput({required this.values});
+
+  factory LeadInput.empty() {
+    return LeadInput(values: {
+      'age': null,
+      'education': null,
+      'occupation': null,
+      'take_home_exposure': null,
+      'water_source': null,
+      'kohl_usage': null,
+      'lipstick_usage': null,
+      'sindoor_usage': null,
+      'utensils': null,
+      'non_specific_symptoms': null,
+      'gastrointestinal': null,
+      'pica_symptoms': null,
+      'mother_bll': null,
+    });
+  }
+
+  LeadInput copyWithField(String key, String? value) {
+    final updated = Map<String, String?>.from(values);
+    updated[key] = value;
+    return LeadInput(values: updated);
+  }
+
+  bool get isComplete => values.values.every((value) => value != null && value!.isNotEmpty);
+
+  Map<String, String> asDisplayMap() {
+    return values.map((key, value) => MapEntry(
+          _formatKey(key),
+          value != null ? _formatValue(value) : 'Not selected',
+        ));
+  }
+
+  String _formatKey(String key) {
+    final words = key.split('_').map((word) {
+      if (word.toLowerCase() == 'bll') {
+        return 'BLL';
+      }
+      return word[0].toUpperCase() + word.substring(1);
+    }).toList();
+    return words.join(' ');
+  }
+
+  String _formatValue(String value) {
+    return value
+        .replaceAll('_', ' ')
+        .replaceAll(RegExp(r'(?<!^)([A-Z])'), ' $1')
+        .trim();
+  }
+}

--- a/lib/models/prediction_result.dart
+++ b/lib/models/prediction_result.dart
@@ -1,0 +1,6 @@
+class PredictionResult {
+  final double predictedBll;
+  final String riskLevel;
+
+  PredictionResult({required this.predictedBll, required this.riskLevel});
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import '../controllers/lead_prediction_controller.dart';
+import 'input_form_page.dart';
+import 'results_page.dart';
+import 'suggestions_page.dart';
+import 'lead_toxicity_page.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  int _selectedIndex = 0;
+  late final LeadPredictionController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = LeadPredictionController();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tabs = [
+      InputFormPage(controller: _controller),
+      ResultsPage(controller: _controller),
+      SuggestionsPage(controller: _controller),
+      const LeadToxicityPage(),
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Lead Level Predictor'),
+        centerTitle: true,
+      ),
+      body: IndexedStack(
+        index: _selectedIndex,
+        children: tabs,
+      ),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: _selectedIndex,
+        onDestinationSelected: (index) => setState(() => _selectedIndex = index),
+        destinations: const [
+          NavigationDestination(
+            icon: Icon(Icons.list_alt_outlined),
+            selectedIcon: Icon(Icons.list_alt),
+            label: 'Input',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.insights_outlined),
+            selectedIcon: Icon(Icons.insights),
+            label: 'Results',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.health_and_safety_outlined),
+            selectedIcon: Icon(Icons.health_and_safety),
+            label: 'Suggestions',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.menu_book_outlined),
+            selectedIcon: Icon(Icons.menu_book),
+            label: 'Lead Toxicity',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/input_form_page.dart
+++ b/lib/screens/input_form_page.dart
@@ -1,0 +1,367 @@
+import 'package:flutter/material.dart';
+import '../controllers/lead_prediction_controller.dart';
+
+class InputFormPage extends StatefulWidget {
+  const InputFormPage({super.key, required this.controller});
+
+  final LeadPredictionController controller;
+
+  @override
+  State<InputFormPage> createState() => _InputFormPageState();
+}
+
+class _InputFormPageState extends State<InputFormPage> {
+  final PageController _pageController = PageController();
+  final List<GlobalKey<FormState>> _formKeys =
+      List.generate(3, (_) => GlobalKey<FormState>());
+  int _currentPage = 0;
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  void _goToPage(int page) {
+    setState(() {
+      _currentPage = page;
+    });
+    _pageController.animateToPage(
+      page,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void _handleNext() {
+    final currentForm = _formKeys[_currentPage].currentState;
+    if (currentForm != null && currentForm.validate()) {
+      if (_currentPage < 2) {
+        _goToPage(_currentPage + 1);
+      } else {
+        widget.controller.predict();
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Prediction updated. Check the results tab.')),
+        );
+      }
+    }
+  }
+
+  void _handlePrevious() {
+    if (_currentPage > 0) {
+      _goToPage(_currentPage - 1);
+    }
+  }
+
+  void _resetForm() {
+    widget.controller.reset();
+    for (final key in _formKeys) {
+      key.currentState?.reset();
+    }
+    _goToPage(0);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Input Information', style: textTheme.headlineSmall),
+              const SizedBox(height: 8),
+              Text(
+                'Fill in the child and household details. Use the Next button to move between pages.',
+                style: textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 16),
+              LinearProgressIndicator(value: (_currentPage + 1) / 3),
+              const SizedBox(height: 8),
+              Text('Page ${_currentPage + 1} of 3', style: textTheme.labelLarge),
+            ],
+          ),
+        ),
+        Expanded(
+          child: PageView(
+            controller: _pageController,
+            physics: const NeverScrollableScrollPhysics(),
+            children: [
+              _buildPage(
+                formKey: _formKeys[0],
+                children: [
+                  _buildDropdown(
+                    label: 'Age',
+                    fieldKey: 'age',
+                    options: const ['Less than or Equal to 30', 'Greater than 30'],
+                  ),
+                  _buildDropdown(
+                    label: 'Education',
+                    fieldKey: 'education',
+                    options: const ['College_HigherDegree', 'NoCollege'],
+                  ),
+                  _buildDropdown(
+                    label: 'Occupation',
+                    fieldKey: 'occupation',
+                    options: const [
+                      'Housewife',
+                      'Agriculture',
+                      'AutoDriver',
+                      'AutoDriver_Ceramics',
+                      'AutoRepair',
+                      'Batteries',
+                      'Batteries_Lock',
+                      'Ceramics',
+                      'Construction_Furniture',
+                      'Construction_Painting_Plastic_Polishing',
+                      'Driver',
+                      'Electrician',
+                      'Engineer',
+                      'Factory',
+                      'Foundry',
+                      'Gold',
+                      'HairStylist',
+                      'Iron',
+                      'Machinery',
+                      'Mechanic',
+                      'None',
+                      'Painting',
+                      'Painting_Furniture',
+                      'Painting_Polishing',
+                      'Plastic',
+                      'Plastic-Manufacturing_Soldering',
+                      'Polishing',
+                      'Polishing_Soldering',
+                      'Soldering',
+                      'Steel',
+                      'Other',
+                    ],
+                  ),
+                  _buildDropdown(
+                    label: 'Take Home Exposure',
+                    fieldKey: 'take_home_exposure',
+                    options: const [
+                      'Agriculture',
+                      'AutoDriver',
+                      'AutoDriver_Ceramics',
+                      'AutoRepair',
+                      'Batteries',
+                      'Batteries_Lock',
+                      'Ceramics',
+                      'Construction_Furniture',
+                      'Construction_Painting_Plastic_Polishing',
+                      'Driver',
+                      'Electrician',
+                      'Engineer',
+                      'Factory',
+                      'Foundry',
+                      'Gold',
+                      'HairStylist',
+                      'Iron',
+                      'Machinery',
+                      'Mechanic',
+                      'None',
+                      'Painting',
+                      'Painting_Furniture',
+                      'Painting_Polishing',
+                      'Plastic',
+                      'Plastic-Manufacturing_Soldering',
+                      'Polishing',
+                      'Polishing_Soldering',
+                      'Soldering',
+                      'Steel',
+                      'Other',
+                    ],
+                  ),
+                ],
+              ),
+              _buildPage(
+                formKey: _formKeys[1],
+                children: [
+                  _buildDropdown(
+                    label: 'Primary Water Source',
+                    fieldKey: 'water_source',
+                    options: const [
+                      'GroundWater',
+                      'GroundWater_ROWater',
+                      'GroundWater_TapWater',
+                      'ROWater',
+                      'TapWater',
+                    ],
+                  ),
+                  _buildDropdown(
+                    label: 'Kohl Usage',
+                    fieldKey: 'kohl_usage',
+                    options: const ['Yes', 'No'],
+                  ),
+                  _buildDropdown(
+                    label: 'Lipstick Usage',
+                    fieldKey: 'lipstick_usage',
+                    options: const ['Yes', 'No'],
+                  ),
+                  _buildDropdown(
+                    label: 'Sindoor Usage',
+                    fieldKey: 'sindoor_usage',
+                    options: const ['Yes', 'No'],
+                  ),
+                ],
+              ),
+              _buildPage(
+                formKey: _formKeys[2],
+                children: [
+                  _buildDropdown(
+                    label: 'Utensils',
+                    fieldKey: 'utensils',
+                    options: const [
+                      'Aluminium',
+                      'Aluminium_Ceramic_Steel',
+                      'Aluminium_Steel',
+                      'Other_Steel',
+                      'Steel',
+                    ],
+                  ),
+                  _buildDropdown(
+                    label: 'Non-specific Symptoms',
+                    fieldKey: 'non_specific_symptoms',
+                    options: const [
+                      'Headache',
+                      'Headache_Lethargy',
+                      'Headache_Tiredness',
+                      'Lethargy',
+                      'Lethargy_Tiredness',
+                      'No',
+                      'Tiredness',
+                    ],
+                  ),
+                  _buildDropdown(
+                    label: 'Gastrointestinal Symptoms',
+                    fieldKey: 'gastrointestinal',
+                    options: const [
+                      'Anorexia',
+                      'Anorexia_PainAbdomen',
+                      'Constipation',
+                      'No',
+                      'PainAbdomen',
+                    ],
+                  ),
+                  Padding(
+                    padding: EdgeInsets.zero,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Additional Health History',
+                          style: Theme.of(context).textTheme.titleSmall,
+                        ),
+                        const SizedBox(height: 8),
+                        _buildDropdown(
+                          label: 'Pica Symptoms',
+                          fieldKey: 'pica_symptoms',
+                          options: const [
+                            'CalciumDeficiency',
+                            'IronDeficiency',
+                            'No',
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        _buildDropdown(
+                          label: 'Mother Blood Lead Level',
+                          fieldKey: 'mother_bll',
+                          options: const [
+                            'ND_5',
+                            'Between5_10',
+                            'Between10_15',
+                            'GreaterThan15',
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Row(
+            children: [
+              if (_currentPage > 0)
+                TextButton.icon(
+                  onPressed: _handlePrevious,
+                  icon: const Icon(Icons.arrow_back),
+                  label: const Text('Previous'),
+                ),
+              if (_currentPage == 0)
+                TextButton.icon(
+                  onPressed: _resetForm,
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('Reset'),
+                ),
+              const Spacer(),
+              ElevatedButton.icon(
+                onPressed: _handleNext,
+                icon: Icon(_currentPage == 2 ? Icons.check_circle : Icons.arrow_forward),
+                label: Text(_currentPage == 2 ? 'Calculate' : 'Next'),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPage({required GlobalKey<FormState> formKey, required List<Widget> children}) {
+    return Form(
+      key: formKey,
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Column(
+          children: [
+            for (final child in children) ...[
+              child,
+              const SizedBox(height: 16),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDropdown({
+    required String label,
+    required String fieldKey,
+    required List<String> options,
+  }) {
+    final currentValue = widget.controller.input.values[fieldKey];
+    return DropdownButtonFormField<String>(
+      value: currentValue,
+      decoration: InputDecoration(
+        labelText: label,
+        border: const OutlineInputBorder(),
+      ),
+      items: options
+          .map((value) => DropdownMenuItem<String>(
+                value: value,
+                child: Text(_humanize(value)),
+              ))
+          .toList(),
+      onChanged: (value) {
+        widget.controller.updateField(fieldKey, value);
+        setState(() {});
+      },
+      validator: (value) => value == null || value.isEmpty ? 'Please select an option' : null,
+    );
+  }
+
+  String _humanize(String value) {
+    return value
+        .replaceAll('_', ' ')
+        .replaceAll(RegExp(r'(?<!^)([A-Z])'), ' $1')
+        .trim();
+  }
+}

--- a/lib/screens/lead_toxicity_page.dart
+++ b/lib/screens/lead_toxicity_page.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+class LeadToxicityPage extends StatelessWidget {
+  const LeadToxicityPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Text('Lead Toxicity', style: textTheme.headlineSmall),
+        const SizedBox(height: 12),
+        Text(
+          'Lead toxicity occurs when lead builds up in the body over time. Even low levels of lead can impair the nervous system, affect learning, and slow growth in young children.',
+          style: textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 16),
+        _buildSection(
+          title: 'Common Sources',
+          bullets: const [
+            'Peeling paint in houses built before 1978 and the dust created when it chips.',
+            'Contaminated soil near roads, industrial sites, and informal recycling units.',
+            'Lead-glazed pottery, soldered food cans, cosmetics such as kohl and sindoor.',
+            'Drinking water travelling through old lead pipes or fittings.',
+          ],
+          textTheme: textTheme,
+        ),
+        _buildSection(
+          title: 'Health Effects',
+          bullets: const [
+            'Slowed growth and development in infants and children.',
+            'Learning problems, lower IQ, irritability, and behavioural changes.',
+            'Abdominal pain, constipation, headaches, and fatigue.',
+            'In severe cases, seizures, hearing loss, or anemia.',
+          ],
+          textTheme: textTheme,
+        ),
+        _buildSection(
+          title: 'Prevention Tips',
+          bullets: const [
+            'Wash hands, toys, and bottles regularly to remove settled dust.',
+            'Use wet mopping instead of dry sweeping to limit dust circulation.',
+            'Provide iron, calcium, and vitamin C rich meals to block lead absorption.',
+            'Use certified filters and flush taps before using water for drinking or cooking.',
+            'Avoid storing food in low-quality metal containers or chipped ceramics.',
+          ],
+          textTheme: textTheme,
+        ),
+        _buildSection(
+          title: 'When to Seek Help',
+          bullets: const [
+            'If a child shows persistent symptoms such as abdominal pain, lethargy, or pica.',
+            'When living near industries or jobs involving batteries, smelting, or painting.',
+            'If previous blood tests indicated elevated lead levels.',
+            'Whenever a caregiver suspects exposure to lead dust or flakes at home.',
+          ],
+          textTheme: textTheme,
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'Early identification and intervention drastically lower the long-term impact of lead poisoning. Combine regular screening with the preventive steps above to keep families safe.',
+          style: textTheme.bodyMedium,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSection({
+    required String title,
+    required List<String> bullets,
+    required TextTheme textTheme,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: textTheme.titleMedium),
+        const SizedBox(height: 8),
+        ...bullets.map(
+          (bullet) => Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('• '),
+                Expanded(child: Text(bullet, style: textTheme.bodyMedium)),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+}

--- a/lib/screens/results_page.dart
+++ b/lib/screens/results_page.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import '../controllers/lead_prediction_controller.dart';
+
+class ResultsPage extends StatelessWidget {
+  const ResultsPage({super.key, required this.controller});
+
+  final LeadPredictionController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (context, _) {
+        if (!controller.hasPredicted) {
+          return _buildPlaceholder(textTheme);
+        }
+
+        final result = controller.result;
+        final entries = controller.input.asDisplayMap().entries.toList();
+
+        return ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            Text('Results', style: textTheme.headlineSmall),
+            const SizedBox(height: 12),
+            if (result != null && result.riskLevel != 'Incomplete input')
+              Card(
+                elevation: 0,
+                color: Theme.of(context).colorScheme.primaryContainer,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Predicted Blood Lead Level',
+                        style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        '${result.predictedBll.toStringAsFixed(2)} µg/dL',
+                        style: textTheme.displaySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.onPrimaryContainer,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Chip(
+                        label: Text('${result.riskLevel} risk'),
+                        avatar: const Icon(Icons.warning_amber_outlined),
+                      ),
+                    ],
+                  ),
+                ),
+              )
+            else
+              Card(
+                elevation: 0,
+                color: Theme.of(context).colorScheme.errorContainer,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.info_outline),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Text(
+                          'Complete all inputs to generate a prediction.',
+                          style: textTheme.bodyMedium,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            const SizedBox(height: 24),
+            Text('Your Inputs', style: textTheme.titleMedium),
+            const SizedBox(height: 8),
+            ...entries.map(
+              (entry) => Card(
+                child: ListTile(
+                  title: Text(entry.key),
+                  subtitle: Text(entry.value),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildPlaceholder(TextTheme textTheme) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.pending_actions_outlined, size: 72),
+            const SizedBox(height: 16),
+            Text(
+              'No prediction yet',
+              style: textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Complete the three input pages and tap Calculate to view the predicted blood lead level.',
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/suggestions_page.dart
+++ b/lib/screens/suggestions_page.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import '../controllers/lead_prediction_controller.dart';
+import '../services/suggestions_service.dart';
+
+class SuggestionsPage extends StatelessWidget {
+  SuggestionsPage({super.key, required this.controller});
+
+  final LeadPredictionController controller;
+  final SuggestionsService _service = SuggestionsService();
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (context, _) {
+        final suggestions = _service.buildSuggestions(controller.result);
+        return ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            Text('Suggestions', style: textTheme.headlineSmall),
+            const SizedBox(height: 12),
+            if (controller.result != null && controller.result?.riskLevel != 'Incomplete input')
+              _buildRiskSummary(context, controller.result!.riskLevel, textTheme)
+            else
+              _buildPlaceholderCard(context, textTheme),
+            const SizedBox(height: 16),
+            ...suggestions.map(
+              (tip) => Card(
+                child: ListTile(
+                  leading: const Icon(Icons.check_circle_outline),
+                  title: Text(tip),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildRiskSummary(BuildContext context, String riskLevel, TextTheme textTheme) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Card(
+      color: colorScheme.surfaceVariant,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Risk Overview', style: textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text(
+              'Current risk category: $riskLevel',
+              style: textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              _riskDescription(riskLevel),
+              style: textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPlaceholderCard(BuildContext context, TextTheme textTheme) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            const Icon(Icons.health_and_safety_outlined),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                'Enter the exposure details and calculate to receive personalised suggestions.',
+                style: textTheme.bodyMedium,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _riskDescription(String riskLevel) {
+    switch (riskLevel) {
+      case 'Low':
+        return 'Lead level appears low. Continue monitoring and maintain protective habits.';
+      case 'Moderate':
+        return 'Lead level suggests moderate exposure. Follow the steps below to lower the risk.';
+      case 'High':
+        return 'Lead level is high. Please seek medical attention and act on the guidance immediately.';
+      default:
+        return 'Complete the assessment to understand the exposure risk.';
+    }
+  }
+}

--- a/lib/services/prediction_service.dart
+++ b/lib/services/prediction_service.dart
@@ -1,0 +1,175 @@
+import '../models/lead_input.dart';
+import '../models/prediction_result.dart';
+
+class PredictionService {
+  PredictionResult predict(LeadInput input) {
+    if (!input.isComplete) {
+      return PredictionResult(predictedBll: 0, riskLevel: 'Incomplete input');
+    }
+
+    double score = 1.5; // base score
+
+    score += _scoreFor('age', input.values['age']);
+    score += _scoreFor('education', input.values['education']);
+    score += _scoreFor('occupation', input.values['occupation']);
+    score += _scoreFor('take_home_exposure', input.values['take_home_exposure']);
+    score += _scoreFor('water_source', input.values['water_source']);
+    score += _scoreFor('kohl_usage', input.values['kohl_usage']);
+    score += _scoreFor('lipstick_usage', input.values['lipstick_usage']);
+    score += _scoreFor('sindoor_usage', input.values['sindoor_usage']);
+    score += _scoreFor('utensils', input.values['utensils']);
+    score += _scoreFor('non_specific_symptoms', input.values['non_specific_symptoms']);
+    score += _scoreFor('gastrointestinal', input.values['gastrointestinal']);
+    score += _scoreFor('pica_symptoms', input.values['pica_symptoms']);
+    score += _scoreFor('mother_bll', input.values['mother_bll']);
+
+    final double predictedLevel = double.parse(score.toStringAsFixed(2));
+    final String riskLevel;
+
+    if (predictedLevel < 5) {
+      riskLevel = 'Low';
+    } else if (predictedLevel < 10) {
+      riskLevel = 'Moderate';
+    } else {
+      riskLevel = 'High';
+    }
+
+    return PredictionResult(predictedBll: predictedLevel, riskLevel: riskLevel);
+  }
+
+  double _scoreFor(String key, String? value) {
+    if (value == null) return 0;
+    final Map<String, Map<String, double>> scoreTable = {
+      'age': {
+        'Less than or Equal to 30': 1.0,
+        'Greater than 30': 1.8,
+      },
+      'education': {
+        'College_HigherDegree': 0.8,
+        'NoCollege': 1.2,
+      },
+      'occupation': {
+        'Housewife': 0.5,
+        'Agriculture': 1.2,
+        'AutoDriver': 1.5,
+        'AutoDriver_Ceramics': 1.6,
+        'AutoRepair': 1.7,
+        'Batteries': 2.2,
+        'Batteries_Lock': 2.0,
+        'Ceramics': 1.8,
+        'Construction_Furniture': 1.9,
+        'Construction_Painting_Plastic_Polishing': 2.1,
+        'Driver': 1.5,
+        'Electrician': 1.6,
+        'Engineer': 1.1,
+        'Factory': 2.0,
+        'Foundry': 2.2,
+        'Gold': 2.3,
+        'HairStylist': 1.4,
+        'Iron': 2.0,
+        'Machinery': 1.9,
+        'Mechanic': 1.8,
+        'None': 0.3,
+        'Painting': 2.0,
+        'Painting_Furniture': 1.9,
+        'Painting_Polishing': 2.2,
+        'Plastic': 2.1,
+        'Plastic-Manufacturing_Soldering': 2.3,
+        'Polishing': 1.8,
+        'Polishing_Soldering': 2.1,
+        'Soldering': 2.0,
+        'Steel': 1.7,
+        'Other': 1.0,
+      },
+      'take_home_exposure': {
+        'Agriculture': 1.0,
+        'AutoDriver': 1.4,
+        'AutoDriver_Ceramics': 1.5,
+        'AutoRepair': 1.6,
+        'Batteries': 2.4,
+        'Batteries_Lock': 2.2,
+        'Ceramics': 1.7,
+        'Construction_Furniture': 1.8,
+        'Construction_Painting_Plastic_Polishing': 2.0,
+        'Driver': 1.3,
+        'Electrician': 1.5,
+        'Engineer': 1.1,
+        'Factory': 2.1,
+        'Foundry': 2.3,
+        'Gold': 2.4,
+        'HairStylist': 1.3,
+        'Iron': 2.0,
+        'Machinery': 1.8,
+        'Mechanic': 1.9,
+        'None': 0.4,
+        'Painting': 2.0,
+        'Painting_Furniture': 1.9,
+        'Painting_Polishing': 2.2,
+        'Plastic': 2.0,
+        'Plastic-Manufacturing_Soldering': 2.4,
+        'Polishing': 1.9,
+        'Polishing_Soldering': 2.2,
+        'Soldering': 2.1,
+        'Steel': 1.6,
+        'Other': 1.0,
+      },
+      'water_source': {
+        'GroundWater': 1.5,
+        'GroundWater_ROWater': 1.2,
+        'GroundWater_TapWater': 1.4,
+        'ROWater': 0.6,
+        'TapWater': 1.1,
+      },
+      'kohl_usage': {
+        'Yes': 1.4,
+        'No': 0.6,
+      },
+      'lipstick_usage': {
+        'Yes': 1.1,
+        'No': 0.5,
+      },
+      'sindoor_usage': {
+        'Yes': 1.2,
+        'No': 0.4,
+      },
+      'utensils': {
+        'Aluminium': 0.9,
+        'Aluminium_Ceramic_Steel': 0.8,
+        'Aluminium_Steel': 0.9,
+        'Other_Steel': 0.7,
+        'Steel': 0.6,
+      },
+      'non_specific_symptoms': {
+        'Headache': 1.2,
+        'Headache_Lethargy': 1.6,
+        'Headache_Tiredness': 1.4,
+        'Lethargy': 1.1,
+        'Lethargy_Tiredness': 1.3,
+        'No': 0.4,
+        'Tiredness': 1.0,
+      },
+      'gastrointestinal': {
+        'Anorexia': 1.3,
+        'Anorexia_PainAbdomen': 1.8,
+        'Constipation': 1.2,
+        'No': 0.5,
+        'PainAbdomen': 1.4,
+      },
+      'pica_symptoms': {
+        'CalciumDeficiency': 1.6,
+        'IronDeficiency': 1.8,
+        'No': 0.6,
+      },
+      'mother_bll': {
+        'ND_5': 0.5,
+        'Between5_10': 1.3,
+        'Between10_15': 2.0,
+        'GreaterThan15': 2.8,
+      },
+    };
+
+    final valueScores = scoreTable[key];
+    if (valueScores == null) return 0;
+    return valueScores[value] ?? 0.8;
+  }
+}

--- a/lib/services/suggestions_service.dart
+++ b/lib/services/suggestions_service.dart
@@ -1,0 +1,35 @@
+import '../models/prediction_result.dart';
+
+class SuggestionsService {
+  List<String> buildSuggestions(PredictionResult? result) {
+    if (result == null || result.riskLevel == 'Incomplete input') {
+      return const [
+        'Complete the assessment to view tailored suggestions.',
+      ];
+    }
+
+    switch (result.riskLevel) {
+      case 'Low':
+        return const [
+          'Continue regular monitoring of potential lead sources at home.',
+          'Maintain a balanced diet rich in calcium and iron to block lead absorption.',
+          'Schedule periodic re-testing if there is ongoing exposure.',
+        ];
+      case 'Moderate':
+        return const [
+          'Increase cleaning frequency of floors and surfaces to remove lead dust.',
+          'Encourage hand-washing before meals and after outdoor play.',
+          'Use certified water filters and flush taps before use.',
+          'Consult a healthcare provider for targeted blood lead follow-up.',
+        ];
+      case 'High':
+      default:
+        return const [
+          'Seek immediate medical advice for chelation eligibility and follow-up testing.',
+          'Remove or isolate known lead sources such as peeling paint, contaminated soil, or lead-glazed utensils.',
+          'Provide iron, calcium, and vitamin C rich meals to reduce lead absorption.',
+          'Inform local public health authorities about potential community exposure.',
+        ];
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,16 @@
+name: lead_level_predictor
+description: A Flutter app to predict blood lead levels based on user inputs.
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.1.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.6
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- scaffold a Flutter application with navigation between input, results, suggestions, and lead toxicity sections
- implement a three-page dropdown-based intake form covering all exposure features and a placeholder scoring service for predictions
- add contextual suggestions, lead-toxicity education content, and documentation on setup and model replacement

## Testing
- not run (flutter is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d4ebbf3d5c832dad36d7c784214a54