### PR TITLE
Switch to results tab after successful prediction

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -25,7 +25,10 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     final tabs = [
-      InputFormPage(controller: _controller),
+      InputFormPage(
+        controller: _controller,
+        onCompleted: () => setState(() => _selectedIndex = 1),
+      ),
       ResultsPage(controller: _controller),
       SuggestionsPage(controller: _controller),
       const LeadToxicityPage(),

--- a/lib/screens/input_form_page.dart
+++ b/lib/screens/input_form_page.dart
@@ -2,9 +2,14 @@ import 'package:flutter/material.dart';
 import '../controllers/lead_prediction_controller.dart';
 
 class InputFormPage extends StatefulWidget {
-  const InputFormPage({super.key, required this.controller});
+  const InputFormPage({
+    super.key,
+    required this.controller,
+    this.onCompleted,
+  });
 
   final LeadPredictionController controller;
+  final VoidCallback? onCompleted;
 
   @override
   State<InputFormPage> createState() => _InputFormPageState();
@@ -40,6 +45,7 @@ class _InputFormPageState extends State<InputFormPage> {
         _goToPage(_currentPage + 1);
       } else {
         widget.controller.predict();
+        widget.onCompleted?.call();
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Prediction updated. Check the results tab.')),


### PR DESCRIPTION
## Summary
- allow the input form to accept an optional completion callback and trigger it after a successful prediction
- have the home screen pass a completion callback that switches to the results tab when prediction succeeds

## Testing
- not run (manual testing requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddfbd67714832d806655e525cd8497