### PR TITLE
Document model installation steps and auto-open results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+.pub-cache/
+build/
+flutter_*.png
+*.lock
+
+# Android specific
+**/android/**/gradle-wrapper.jar
+**/android/.gradle/
+**/android/app/build/
+**/android/local.properties
+
+# iOS/macOS
+**/ios/Pods/
+**/ios/.symlinks/
+**/ios/Flutter/Flutter.framework
+**/ios/Flutter/Flutter.podspec
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,3 +1,137 @@
+# Lead Level Predictor
 
-# lead_level_predictor
-App to predict the Blood lead level based on some input params
+A Flutter application that collects household and lifestyle details to estimate a child's blood lead level. The interface is divided into four clear sections that mirror the requested layout:
+
+1. **Input Information** – Three paginated forms with four fields per page capture all required categorical features from the dataset (age, education, occupation, take-home exposure, water source, cosmetic usage, utensils, and symptom groups).
+2. **Results** – Displays the full set of inputs alongside the predicted blood lead level and the derived risk category.
+3. **Suggestions** – Generates prevention tips that adapt to the predicted risk level.
+4. **Lead Toxicity** – A concise article that educates users about exposure sources, warning signs, and prevention tactics.
+
+The UI now talks to a TensorFlow Lite interpreter through `PredictionService` so that you can plug in a real trained model without touching the presentation layer.
+
+## Getting Started
+
+1. Install [Flutter](https://docs.flutter.dev/get-started/install) and ensure that `flutter doctor` passes.
+2. (First-time setup only) Generate the native platform folders by running `flutter create .` in the project root. Existing Dart files will be preserved.
+3. Fetch dependencies:
+   ```bash
+   flutter pub get
+   ```
+4. Run the app on an emulator or device:
+   ```bash
+   flutter run
+   ```
+
+## Model Integration Workflow
+
+`PredictionService` loads the TensorFlow Lite model once, encodes the form answers, and performs synchronous inference on the device. To make the pipeline work with your trained artefacts, update the files in `assets/models/`:
+
+| File | Purpose |
+| --- | --- |
+| `assets/models/lead_level_model.tflite` | The exported TensorFlow Lite model. Replace the placeholder file with the real binary produced by your training notebook/script. |
+| `assets/models/feature_metadata.json` | Describes the order of the features, the categorical encodings applied during training, and (optionally) normalisation statistics. Generated once from the preprocessing code so Dart can reproduce the exact transformations. |
+
+The provided `feature_metadata.json` contains ordinal encodings that match the dropdown options in the UI. Adjust it to mirror your real preprocessing steps:
+
+```json
+{
+  "featureOrder": ["age", "education", "occupation", ...],
+  "encodings": {
+    "age": {"Less than or Equal to 30": 0.0, "Greater than 30": 1.0},
+    "occupation": {"Housewife": 0.0, "Agriculture": 1.0, "AutoDriver": 2.0, ...}
+  },
+  "normalization": {
+    "mean": [/* optional per-feature mean */],
+    "std": [/* optional per-feature std-dev */]
+  }
+}
+```
+
+- **Feature order** must match the input tensor expected by the model.
+- **Encodings** map each dropdown choice to the numeric value used during training (one-hot encodings can be represented by multiple numeric columns in the order array).
+- **Normalization** is optional; when provided, the controller applies `(value - mean) / std` before inference.
+
+## Preparing a Python model for integration
+
+If you already trained a model in Python, follow these steps to package it for the Flutter app. The process assumes a TensorFlow/Keras workflow, but the same ideas apply to other frameworks that can export TensorFlow Lite graphs.
+
+1. **Align the training columns with the UI** – Remove the blood-lead-level target (BLL) from the feature matrix and make sure every remaining column corresponds to one of the 12 dropdowns in the app (`age`, `education`, `occupation`, `take_home_exposure`, `water_source`, `kohl_usage`, `lipstick_usage`, `sindoor_usage`, `utensils`, `non_specific_symptoms`, `gastrointestinal`, `pica_symptoms`).
+2. **Encode categories with stable IDs** – Convert each string choice to the numeric value you want to persist in `feature_metadata.json`. The easiest approach is to build `LabelEncoder`-style lookups and dump them to JSON after training so the same mapping is available in Flutter.
+3. **Train and save the TensorFlow model** – Train your network on the encoded features and raw BLL target. Save the resulting model (e.g., `model.save("./export/lead_bll_model")`).
+4. **Export the metadata JSON** – Serialize the feature order and encoding tables you used into the following structure:
+   ```python
+   import json
+
+   feature_order = [
+       "age",
+       "education",
+       "occupation",
+       "take_home_exposure",
+       "water_source",
+       "kohl_usage",
+       "lipstick_usage",
+       "sindoor_usage",
+       "utensils",
+       "non_specific_symptoms",
+       "gastrointestinal",
+       "pica_symptoms",
+   ]
+
+   encodings = {feature: mapping for feature, mapping in your_label_tables.items()}
+
+   with open("feature_metadata.json", "w") as fp:
+       json.dump({"featureOrder": feature_order, "encodings": encodings}, fp, indent=2)
+   ```
+5. **Convert to TensorFlow Lite** – Use the TFLite converter on the SavedModel directory:
+   ```python
+   import tensorflow as tf
+
+   converter = tf.lite.TFLiteConverter.from_saved_model("./export/lead_bll_model")
+   tflite_model = converter.convert()
+
+   with open("lead_level_model.tflite", "wb") as f:
+       f.write(tflite_model)
+   ```
+6. **Copy the artefacts into Flutter** – Replace `assets/models/lead_level_model.tflite` and `assets/models/feature_metadata.json` with the files generated above, then run `flutter pub get` followed by `flutter run`. The app will automatically pick up the new assets at the next launch.
+
+### Installing your `.tflite` file in this repository
+
+Once you have exported the trained model and metadata, drop them into the Flutter project like this:
+
+1. Copy the TensorFlow Lite file into place:
+   ```bash
+   cp /path/to/your/lead_level_model.tflite assets/models/
+   ```
+2. Copy the matching metadata JSON (generated from your preprocessing code) into the same folder:
+   ```bash
+   cp /path/to/your/feature_metadata.json assets/models/
+   ```
+3. (Optional but recommended) Clean any previously cached assets when swapping models:
+   ```bash
+   flutter clean
+   ```
+4. Fetch packages and rebuild the app so the new artefacts are bundled:
+   ```bash
+   flutter pub get
+   flutter run
+   ```
+
+If `flutter run` reports that the model or metadata cannot be loaded, double-check that the filenames exactly match the ones above and that your metadata includes every dropdown option exposed in the UI.
+
+Because the Flutter layer now expects BLL to be predicted, not entered, any attempt to keep a maternal BLL field in `feature_metadata.json` will cause a mismatch error during inference.
+
+If the encoder or model fails to load, the UI surfaces the error in the Results and Suggestions tabs so the user understands what went wrong.
+
+## Project Structure
+
+- `lib/main.dart` – App entry point and theme configuration.
+- `lib/screens/` – UI for each section (input form, results, suggestions, and lead toxicity article).
+- `lib/controllers/` – State management for the collected inputs, asynchronous prediction flow, and error handling.
+- `lib/models/` – Data classes for the form inputs and prediction output.
+- `lib/services/` – TensorFlow Lite integration, feature encoding, and contextual suggestions.
+- `assets/models/` – TensorFlow Lite model plus encoding metadata consumed at runtime.
+
+## Notes
+
+- The suggestion content and lead-toxicity article provide general guidance and should be reviewed by subject matter experts before production use.
+- `flutter pub get` / `flutter run` will fail until you replace the placeholder `lead_level_model.tflite` with a valid TFLite binary generated from your training pipeline.

--- a/assets/models/feature_metadata.json
+++ b/assets/models/feature_metadata.json
@@ -1,0 +1,138 @@
+{
+  "featureOrder": [
+    "age",
+    "education",
+    "occupation",
+    "take_home_exposure",
+    "water_source",
+    "kohl_usage",
+    "lipstick_usage",
+    "sindoor_usage",
+    "utensils",
+    "non_specific_symptoms",
+    "gastrointestinal",
+    "pica_symptoms"
+  ],
+  "encodings": {
+    "age": {
+      "Less than or Equal to 30": 0.0,
+      "Greater than 30": 1.0
+    },
+    "education": {
+      "College_HigherDegree": 0.0,
+      "NoCollege": 1.0
+    },
+    "occupation": {
+      "Housewife": 0.0,
+      "Agriculture": 1.0,
+      "AutoDriver": 2.0,
+      "AutoDriver_Ceramics": 3.0,
+      "AutoRepair": 4.0,
+      "Batteries": 5.0,
+      "Batteries_Lock": 6.0,
+      "Ceramics": 7.0,
+      "Construction_Furniture": 8.0,
+      "Construction_Painting_Plastic_Polishing": 9.0,
+      "Driver": 10.0,
+      "Electrician": 11.0,
+      "Engineer": 12.0,
+      "Factory": 13.0,
+      "Foundry": 14.0,
+      "Gold": 15.0,
+      "HairStylist": 16.0,
+      "Iron": 17.0,
+      "Machinery": 18.0,
+      "Mechanic": 19.0,
+      "None": 20.0,
+      "Painting": 21.0,
+      "Painting_Furniture": 22.0,
+      "Painting_Polishing": 23.0,
+      "Plastic": 24.0,
+      "Plastic-Manufacturing_Soldering": 25.0,
+      "Polishing": 26.0,
+      "Polishing_Soldering": 27.0,
+      "Soldering": 28.0,
+      "Steel": 29.0,
+      "Other": 30.0
+    },
+    "take_home_exposure": {
+      "Agriculture": 0.0,
+      "AutoDriver": 1.0,
+      "AutoDriver_Ceramics": 2.0,
+      "AutoRepair": 3.0,
+      "Batteries": 4.0,
+      "Batteries_Lock": 5.0,
+      "Ceramics": 6.0,
+      "Construction_Furniture": 7.0,
+      "Construction_Painting_Plastic_Polishing": 8.0,
+      "Driver": 9.0,
+      "Electrician": 10.0,
+      "Engineer": 11.0,
+      "Factory": 12.0,
+      "Foundry": 13.0,
+      "Gold": 14.0,
+      "HairStylist": 15.0,
+      "Iron": 16.0,
+      "Machinery": 17.0,
+      "Mechanic": 18.0,
+      "None": 19.0,
+      "Painting": 20.0,
+      "Painting_Furniture": 21.0,
+      "Painting_Polishing": 22.0,
+      "Plastic": 23.0,
+      "Plastic-Manufacturing_Soldering": 24.0,
+      "Polishing": 25.0,
+      "Polishing_Soldering": 26.0,
+      "Soldering": 27.0,
+      "Steel": 28.0,
+      "Other": 29.0
+    },
+    "water_source": {
+      "GroundWater": 0.0,
+      "GroundWater_ROWater": 1.0,
+      "GroundWater_TapWater": 2.0,
+      "ROWater": 3.0,
+      "TapWater": 4.0
+    },
+    "kohl_usage": {
+      "Yes": 1.0,
+      "No": 0.0
+    },
+    "lipstick_usage": {
+      "Yes": 1.0,
+      "No": 0.0
+    },
+    "sindoor_usage": {
+      "Yes": 1.0,
+      "No": 0.0
+    },
+    "utensils": {
+      "Aluminium": 0.0,
+      "Aluminium_Ceramic_Steel": 1.0,
+      "Aluminium_Steel": 2.0,
+      "Other_Steel": 3.0,
+      "Steel": 4.0
+    },
+    "non_specific_symptoms": {
+      "Headache": 0.0,
+      "Headache_Lethargy": 1.0,
+      "Headache_Tiredness": 2.0,
+      "Lethargy": 3.0,
+      "Lethargy_Tiredness": 4.0,
+      "No": 5.0,
+      "Tiredness": 6.0
+    },
+    "gastrointestinal": {
+      "Anorexia": 0.0,
+      "Anorexia_PainAbdomen": 1.0,
+      "Constipation": 2.0,
+      "No": 3.0,
+      "PainAbdomen": 4.0
+    },
+    "pica_symptoms": {
+      "CalciumDeficiency": 0.0,
+      "IronDeficiency": 1.0,
+      "No": 2.0
+    }
+  }
+}

--- a/assets/models/lead_level_model.tflite
+++ b/assets/models/lead_level_model.tflite
@@ -1,0 +1,2 @@
+Placeholder TensorFlow Lite model.
+Replace this file with your trained model exported to TFLite format.

--- a/lib/controllers/lead_prediction_controller.dart
+++ b/lib/controllers/lead_prediction_controller.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import '../models/lead_input.dart';
+import '../models/prediction_result.dart';
+import '../services/prediction_exception.dart';
+import '../services/prediction_service.dart';
+
+class LeadPredictionController extends ChangeNotifier {
+  LeadPredictionController({PredictionService? service})
+      : _service = service ?? PredictionService();
+
+  final PredictionService _service;
+
+  LeadInput input = LeadInput.empty();
+  PredictionResult? _result;
+  bool _isLoading = false;
+  String? _error;
+
+  PredictionResult? get result => _result;
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+
+  void updateField(String key, String? value) {
+    input = input.copyWithField(key, value);
+    _error = null;
+    notifyListeners();
+  }
+
+  Future<void> predict() async {
+    if (_isLoading) return;
+
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      final prediction = await _service.predict(input);
+      _result = prediction;
+    } on PredictionException catch (error) {
+      _error = error.message;
+      _result = null;
+    } catch (error) {
+      _error = 'Something went wrong while running the prediction: $error';
+      _result = null;
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  void reset() {
+    input = LeadInput.empty();
+    _result = null;
+    _isLoading = false;
+    _error = null;
+    notifyListeners();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'screens/home_screen.dart';
+
+void main() {
+  runApp(const LeadLevelPredictorApp());
+}
+
+class LeadLevelPredictorApp extends StatelessWidget {
+  const LeadLevelPredictorApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Lead Level Predictor',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF4F46E5)),
+        useMaterial3: true,
+        textTheme: const TextTheme(
+          bodyMedium: TextStyle(fontSize: 16),
+        ),
+      ),
+      home: const HomeScreen(),
+    );
+  }
+}

--- a/lib/models/lead_input.dart
+++ b/lib/models/lead_input.dart
@@ -1,0 +1,52 @@
+class LeadInput {
+  final Map<String, String?> values;
+
+  LeadInput({required this.values});
+
+  factory LeadInput.empty() {
+    return LeadInput(values: {
+      'age': null,
+      'education': null,
+      'occupation': null,
+      'take_home_exposure': null,
+      'water_source': null,
+      'kohl_usage': null,
+      'lipstick_usage': null,
+      'sindoor_usage': null,
+      'utensils': null,
+      'non_specific_symptoms': null,
+      'gastrointestinal': null,
+      'pica_symptoms': null,
+    });
+  }
+
+  LeadInput copyWithField(String key, String? value) {
+    final updated = Map<String, String?>.from(values);
+    updated[key] = value;
+    return LeadInput(values: updated);
+  }
+
+  bool get isComplete => values.values.every((value) => value != null && value!.isNotEmpty);
+
+  Map<String, String> asDisplayMap() {
+    return values.map((key, value) => MapEntry(
+          _formatKey(key),
+          value != null ? _formatValue(value) : 'Not selected',
+        ));
+  }
+
+  String _formatKey(String key) {
+    final words = key
+        .split('_')
+        .map((word) => word[0].toUpperCase() + word.substring(1))
+        .toList();
+    return words.join(' ');
+  }
+
+  String _formatValue(String value) {
+    return value
+        .replaceAll('_', ' ')
+        .replaceAll(RegExp(r'(?<!^)([A-Z])'), ' $1')
+        .trim();
+  }
+}

--- a/lib/models/prediction_result.dart
+++ b/lib/models/prediction_result.dart
@@ -1,0 +1,6 @@
+class PredictionResult {
+  final double predictedBll;
+  final String riskLevel;
+
+  PredictionResult({required this.predictedBll, required this.riskLevel});
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import '../controllers/lead_prediction_controller.dart';
+import 'input_form_page.dart';
+import 'lead_toxicity_page.dart';
+import 'results_page.dart';
+import 'suggestions_page.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  int _selectedIndex = 0;
+  late final LeadPredictionController _controller;
+
+  void _showResults() {
+    setState(() {
+      _selectedIndex = 1;
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = LeadPredictionController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tabs = [
+      InputFormPage(
+        controller: _controller,
+        onCompleted: _showResults,
+      ),
+      ResultsPage(controller: _controller),
+      SuggestionsPage(controller: _controller),
+      const LeadToxicityPage(),
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Lead Level Predictor'),
+        centerTitle: true,
+      ),
+      body: IndexedStack(
+        index: _selectedIndex,
+        children: tabs,
+      ),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: _selectedIndex,
+        onDestinationSelected: (index) => setState(() => _selectedIndex = index),
+        destinations: const [
+          NavigationDestination(
+            icon: Icon(Icons.list_alt_outlined),
+            selectedIcon: Icon(Icons.list_alt),
+            label: 'Input',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.insights_outlined),
+            selectedIcon: Icon(Icons.insights),
+            label: 'Results',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.health_and_safety_outlined),
+            selectedIcon: Icon(Icons.health_and_safety),
+            label: 'Suggestions',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.menu_book_outlined),
+            selectedIcon: Icon(Icons.menu_book),
+            label: 'Lead Toxicity',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/input_form_page.dart
+++ b/lib/screens/input_form_page.dart
@@ -1,0 +1,430 @@
+import 'package:flutter/material.dart';
+
+import '../controllers/lead_prediction_controller.dart';
+
+class InputFormPage extends StatefulWidget {
+  const InputFormPage({
+    super.key,
+    required this.controller,
+    this.onCompleted,
+  });
+
+  final LeadPredictionController controller;
+  final VoidCallback? onCompleted;
+
+  @override
+  State<InputFormPage> createState() => _InputFormPageState();
+}
+
+class _InputFormPageState extends State<InputFormPage> {
+  final PageController _pageController = PageController();
+  final List<GlobalKey<FormState>> _formKeys =
+      List.generate(3, (_) => GlobalKey<FormState>());
+  int _currentPage = 0;
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  void _goToPage(int page) {
+    setState(() {
+      _currentPage = page;
+    });
+    _pageController.animateToPage(
+      page,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  Future<void> _handleNext() async {
+    final currentForm = _formKeys[_currentPage].currentState;
+    if (currentForm != null && currentForm.validate()) {
+      if (_currentPage < 2) {
+        _goToPage(_currentPage + 1);
+      } else {
+        FocusScope.of(context).unfocus();
+        await widget.controller.predict();
+        if (!mounted) return;
+        final theme = Theme.of(context);
+        final error = widget.controller.error;
+        final messenger = ScaffoldMessenger.of(context);
+        messenger.hideCurrentSnackBar();
+        if (error == null) {
+          widget.onCompleted?.call();
+        }
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(
+              error ?? 'Prediction updated. Showing results.',
+            ),
+            backgroundColor: error != null
+                ? theme.colorScheme.errorContainer
+                : theme.colorScheme.primaryContainer,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    }
+  }
+
+  void _handlePrevious() {
+    if (_currentPage > 0) {
+      _goToPage(_currentPage - 1);
+    }
+  }
+
+  void _resetForm() {
+    widget.controller.reset();
+    for (final key in _formKeys) {
+      key.currentState?.reset();
+    }
+    _goToPage(0);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: widget.controller,
+      builder: (context, _) {
+        final textTheme = Theme.of(context).textTheme;
+        final colorScheme = Theme.of(context).colorScheme;
+        final isLoading = widget.controller.isLoading;
+        final error = widget.controller.error;
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Input Information', style: textTheme.headlineSmall),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Fill in the child and household details. Use the Next button to move between pages.',
+                    style: textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 16),
+                  LinearProgressIndicator(value: (_currentPage + 1) / 3),
+                  const SizedBox(height: 8),
+                  Text('Page ${_currentPage + 1} of 3', style: textTheme.labelLarge),
+                ],
+              ),
+            ),
+            if (error != null)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Card(
+                  color: colorScheme.errorContainer,
+                  elevation: 0,
+                  child: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: Row(
+                      children: [
+                        Icon(
+                          Icons.error_outline,
+                          color: colorScheme.onErrorContainer,
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Text(
+                            error,
+                            style: textTheme.bodyMedium?.copyWith(
+                              color: colorScheme.onErrorContainer,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            Expanded(
+              child: PageView(
+                controller: _pageController,
+                physics: const NeverScrollableScrollPhysics(),
+                children: [
+                  _buildPage(
+                    formKey: _formKeys[0],
+                    children: [
+                      _buildDropdown(
+                        label: 'Age',
+                        fieldKey: 'age',
+                        options: const ['Less than or Equal to 30', 'Greater than 30'],
+                      ),
+                      _buildDropdown(
+                        label: 'Education',
+                        fieldKey: 'education',
+                        options: const ['College_HigherDegree', 'NoCollege'],
+                      ),
+                      _buildDropdown(
+                        label: 'Occupation',
+                        fieldKey: 'occupation',
+                        options: const [
+                          'Housewife',
+                          'Agriculture',
+                          'AutoDriver',
+                          'AutoDriver_Ceramics',
+                          'AutoRepair',
+                          'Batteries',
+                          'Batteries_Lock',
+                          'Ceramics',
+                          'Construction_Furniture',
+                          'Construction_Painting_Plastic_Polishing',
+                          'Driver',
+                          'Electrician',
+                          'Engineer',
+                          'Factory',
+                          'Foundry',
+                          'Gold',
+                          'HairStylist',
+                          'Iron',
+                          'Machinery',
+                          'Mechanic',
+                          'None',
+                          'Painting',
+                          'Painting_Furniture',
+                          'Painting_Polishing',
+                          'Plastic',
+                          'Plastic-Manufacturing_Soldering',
+                          'Polishing',
+                          'Polishing_Soldering',
+                          'Soldering',
+                          'Steel',
+                          'Other',
+                        ],
+                      ),
+                      _buildDropdown(
+                        label: 'Take Home Exposure',
+                        fieldKey: 'take_home_exposure',
+                        options: const [
+                          'Agriculture',
+                          'AutoDriver',
+                          'AutoDriver_Ceramics',
+                          'AutoRepair',
+                          'Batteries',
+                          'Batteries_Lock',
+                          'Ceramics',
+                          'Construction_Furniture',
+                          'Construction_Painting_Plastic_Polishing',
+                          'Driver',
+                          'Electrician',
+                          'Engineer',
+                          'Factory',
+                          'Foundry',
+                          'Gold',
+                          'HairStylist',
+                          'Iron',
+                          'Machinery',
+                          'Mechanic',
+                          'None',
+                          'Painting',
+                          'Painting_Furniture',
+                          'Painting_Polishing',
+                          'Plastic',
+                          'Plastic-Manufacturing_Soldering',
+                          'Polishing',
+                          'Polishing_Soldering',
+                          'Soldering',
+                          'Steel',
+                          'Other',
+                        ],
+                      ),
+                    ],
+                  ),
+                  _buildPage(
+                    formKey: _formKeys[1],
+                    children: [
+                      _buildDropdown(
+                        label: 'Primary Water Source',
+                        fieldKey: 'water_source',
+                        options: const [
+                          'GroundWater',
+                          'GroundWater_ROWater',
+                          'GroundWater_TapWater',
+                          'ROWater',
+                          'TapWater',
+                        ],
+                      ),
+                      _buildDropdown(
+                        label: 'Kohl Usage',
+                        fieldKey: 'kohl_usage',
+                        options: const ['Yes', 'No'],
+                      ),
+                      _buildDropdown(
+                        label: 'Lipstick Usage',
+                        fieldKey: 'lipstick_usage',
+                        options: const ['Yes', 'No'],
+                      ),
+                      _buildDropdown(
+                        label: 'Sindoor Usage',
+                        fieldKey: 'sindoor_usage',
+                        options: const ['Yes', 'No'],
+                      ),
+                    ],
+                  ),
+                  _buildPage(
+                    formKey: _formKeys[2],
+                    children: [
+                      _buildDropdown(
+                        label: 'Utensils',
+                        fieldKey: 'utensils',
+                        options: const [
+                          'Aluminium',
+                          'Aluminium_Ceramic_Steel',
+                          'Aluminium_Steel',
+                          'Other_Steel',
+                          'Steel',
+                        ],
+                      ),
+                      _buildDropdown(
+                        label: 'Non-specific Symptoms',
+                        fieldKey: 'non_specific_symptoms',
+                        options: const [
+                          'Headache',
+                          'Headache_Lethargy',
+                          'Headache_Tiredness',
+                          'Lethargy',
+                          'Lethargy_Tiredness',
+                          'No',
+                          'Tiredness',
+                        ],
+                      ),
+                      _buildDropdown(
+                        label: 'Gastrointestinal Symptoms',
+                        fieldKey: 'gastrointestinal',
+                        options: const [
+                          'Anorexia',
+                          'Anorexia_PainAbdomen',
+                          'Constipation',
+                          'No',
+                          'PainAbdomen',
+                        ],
+                      ),
+                      Padding(
+                        padding: EdgeInsets.zero,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Additional Health History',
+                              style: Theme.of(context).textTheme.titleSmall,
+                            ),
+                            const SizedBox(height: 8),
+                            _buildDropdown(
+                              label: 'Pica Symptoms',
+                              fieldKey: 'pica_symptoms',
+                              options: const [
+                                'CalciumDeficiency',
+                                'IronDeficiency',
+                                'No',
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Row(
+                children: [
+                  if (_currentPage > 0)
+                    TextButton.icon(
+                      onPressed: isLoading ? null : _handlePrevious,
+                      icon: const Icon(Icons.arrow_back),
+                      label: const Text('Previous'),
+                    ),
+                  if (_currentPage == 0)
+                    TextButton.icon(
+                      onPressed: isLoading ? null : _resetForm,
+                      icon: const Icon(Icons.refresh),
+                      label: const Text('Reset'),
+                    ),
+                  const Spacer(),
+                  ElevatedButton.icon(
+                    onPressed: isLoading
+                        ? null
+                        : () async => await _handleNext(),
+                    icon: isLoading && _currentPage == 2
+                        ? SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: Theme.of(context).colorScheme.onPrimary,
+                            ),
+                          )
+                        : Icon(_currentPage == 2 ? Icons.check_circle : Icons.arrow_forward),
+                    label: Text(
+                      _currentPage == 2
+                          ? (isLoading ? 'Calculating…' : 'Calculate')
+                          : 'Next',
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildPage({required GlobalKey<FormState> formKey, required List<Widget> children}) {
+    return Form(
+      key: formKey,
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Column(
+          children: [
+            for (final child in children) ...[
+              child,
+              const SizedBox(height: 16),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDropdown({
+    required String label,
+    required String fieldKey,
+    required List<String> options,
+  }) {
+    final currentValue = widget.controller.input.values[fieldKey];
+    return DropdownButtonFormField<String>(
+      value: currentValue,
+      decoration: InputDecoration(
+        labelText: label,
+        border: const OutlineInputBorder(),
+      ),
+      items: options
+          .map((value) => DropdownMenuItem<String>(
+                value: value,
+                child: Text(_humanize(value)),
+              ))
+          .toList(),
+      onChanged: (value) {
+        widget.controller.updateField(fieldKey, value);
+        setState(() {});
+      },
+      validator: (value) => value == null || value.isEmpty ? 'Please select an option' : null,
+    );
+  }
+
+  String _humanize(String value) {
+    return value
+        .replaceAll('_', ' ')
+        .replaceAll(RegExp(r'(?<!^)([A-Z])'), ' $1')
+        .trim();
+  }
+}

--- a/lib/screens/lead_toxicity_page.dart
+++ b/lib/screens/lead_toxicity_page.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+class LeadToxicityPage extends StatelessWidget {
+  const LeadToxicityPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Text('Lead Toxicity', style: textTheme.headlineSmall),
+        const SizedBox(height: 12),
+        Text(
+          'Lead toxicity occurs when lead builds up in the body over time. Even low levels of lead can impair the nervous system, affect learning, and slow growth in young children.',
+          style: textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 16),
+        _buildSection(
+          title: 'Common Sources',
+          bullets: const [
+            'Peeling paint in houses built before 1978 and the dust created when it chips.',
+            'Contaminated soil near roads, industrial sites, and informal recycling units.',
+            'Lead-glazed pottery, soldered food cans, cosmetics such as kohl and sindoor.',
+            'Drinking water travelling through old lead pipes or fittings.',
+          ],
+          textTheme: textTheme,
+        ),
+        _buildSection(
+          title: 'Health Effects',
+          bullets: const [
+            'Slowed growth and development in infants and children.',
+            'Learning problems, lower IQ, irritability, and behavioural changes.',
+            'Abdominal pain, constipation, headaches, and fatigue.',
+            'In severe cases, seizures, hearing loss, or anemia.',
+          ],
+          textTheme: textTheme,
+        ),
+        _buildSection(
+          title: 'Prevention Tips',
+          bullets: const [
+            'Wash hands, toys, and bottles regularly to remove settled dust.',
+            'Use wet mopping instead of dry sweeping to limit dust circulation.',
+            'Provide iron, calcium, and vitamin C rich meals to block lead absorption.',
+            'Use certified filters and flush taps before using water for drinking or cooking.',
+            'Avoid storing food in low-quality metal containers or chipped ceramics.',
+          ],
+          textTheme: textTheme,
+        ),
+        _buildSection(
+          title: 'When to Seek Help',
+          bullets: const [
+            'If a child shows persistent symptoms such as abdominal pain, lethargy, or pica.',
+            'When living near industries or jobs involving batteries, smelting, or painting.',
+            'If previous blood tests indicated elevated lead levels.',
+            'Whenever a caregiver suspects exposure to lead dust or flakes at home.',
+          ],
+          textTheme: textTheme,
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'Early identification and intervention drastically lower the long-term impact of lead poisoning. Combine regular screening with the preventive steps above to keep families safe.',
+          style: textTheme.bodyMedium,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSection({
+    required String title,
+    required List<String> bullets,
+    required TextTheme textTheme,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: textTheme.titleMedium),
+        const SizedBox(height: 8),
+        ...bullets.map(
+          (bullet) => Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('• '),
+                Expanded(child: Text(bullet, style: textTheme.bodyMedium)),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+}

--- a/lib/screens/results_page.dart
+++ b/lib/screens/results_page.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+
+import '../controllers/lead_prediction_controller.dart';
+
+class ResultsPage extends StatelessWidget {
+  const ResultsPage({super.key, required this.controller});
+
+  final LeadPredictionController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (context, _) {
+        if (controller.isLoading) {
+          return _buildLoading(textTheme);
+        }
+
+        final error = controller.error;
+        if (error != null) {
+          return _buildErrorView(context, textTheme, error);
+        }
+
+        final result = controller.result;
+        if (result == null) {
+          return _buildPlaceholder(textTheme);
+        }
+
+        final entries = controller.input.asDisplayMap().entries.toList();
+
+        return ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            Text('Results', style: textTheme.headlineSmall),
+            const SizedBox(height: 12),
+            Card(
+              elevation: 0,
+              color: Theme.of(context).colorScheme.primaryContainer,
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Predicted Blood Lead Level',
+                      style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      '${result.predictedBll.toStringAsFixed(2)} µg/dL',
+                      style: textTheme.displaySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onPrimaryContainer,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Chip(
+                      label: Text('${result.riskLevel} risk'),
+                      avatar: const Icon(Icons.warning_amber_outlined),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text('Your Inputs', style: textTheme.titleMedium),
+            const SizedBox(height: 8),
+            ...entries.map(
+              (entry) => Card(
+                child: ListTile(
+                  title: Text(entry.key),
+                  subtitle: Text(entry.value),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildLoading(TextTheme textTheme) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const CircularProgressIndicator(),
+          const SizedBox(height: 16),
+          Text('Calculating prediction…', style: textTheme.titleMedium),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildErrorView(BuildContext context, TextTheme textTheme, String message) {
+    final entries = controller.input.asDisplayMap().entries.toList();
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Text('Results', style: textTheme.headlineSmall),
+        const SizedBox(height: 12),
+        Card(
+          color: colorScheme.errorContainer,
+          elevation: 0,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(Icons.error_outline, color: colorScheme.onErrorContainer),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    message,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: colorScheme.onErrorContainer,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 24),
+        if (entries.isNotEmpty) ...[
+          Text('Your Inputs', style: textTheme.titleMedium),
+          const SizedBox(height: 8),
+          ...entries.map(
+            (entry) => Card(
+              child: ListTile(
+                title: Text(entry.key),
+                subtitle: Text(entry.value),
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildPlaceholder(TextTheme textTheme) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.pending_actions_outlined, size: 72),
+            const SizedBox(height: 16),
+            Text(
+              'No prediction yet',
+              style: textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Complete the three input pages and tap Calculate to view the predicted blood lead level.',
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/suggestions_page.dart
+++ b/lib/screens/suggestions_page.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+
+import '../controllers/lead_prediction_controller.dart';
+import '../services/suggestions_service.dart';
+
+class SuggestionsPage extends StatelessWidget {
+  SuggestionsPage({super.key, required this.controller});
+
+  final LeadPredictionController controller;
+  final SuggestionsService _service = SuggestionsService();
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (context, _) {
+        if (controller.isLoading) {
+          return _buildLoading(textTheme);
+        }
+
+        final error = controller.error;
+        if (error != null) {
+          return _buildError(context, textTheme, error);
+        }
+
+        final suggestions = _service.buildSuggestions(controller.result);
+        final riskLevel = controller.result?.riskLevel;
+
+        return ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            Text('Suggestions', style: textTheme.headlineSmall),
+            const SizedBox(height: 12),
+            if (riskLevel != null)
+              _buildRiskSummary(context, riskLevel, textTheme)
+            else
+              _buildPlaceholderCard(context, textTheme),
+            const SizedBox(height: 16),
+            ...suggestions.map(
+              (tip) => Card(
+                child: ListTile(
+                  leading: const Icon(Icons.check_circle_outline),
+                  title: Text(tip),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildRiskSummary(BuildContext context, String riskLevel, TextTheme textTheme) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Card(
+      color: colorScheme.surfaceVariant,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Risk Overview', style: textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text(
+              'Current risk category: $riskLevel',
+              style: textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 4),
+            Text(
+              _riskDescription(riskLevel),
+              style: textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPlaceholderCard(BuildContext context, TextTheme textTheme) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            const Icon(Icons.health_and_safety_outlined),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                'Enter the exposure details and calculate to receive personalised suggestions.',
+                style: textTheme.bodyMedium,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLoading(TextTheme textTheme) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const CircularProgressIndicator(),
+          const SizedBox(height: 16),
+          Text('Preparing suggestions…', style: textTheme.titleMedium),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildError(BuildContext context, TextTheme textTheme, String message) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Card(
+        color: colorScheme.errorContainer,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(Icons.error_outline, color: colorScheme.onErrorContainer),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  message,
+                  style: textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onErrorContainer,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _riskDescription(String riskLevel) {
+    switch (riskLevel) {
+      case 'Low':
+        return 'Lead level appears low. Continue monitoring and maintain protective habits.';
+      case 'Moderate':
+        return 'Lead level suggests moderate exposure. Follow the steps below to lower the risk.';
+      case 'High':
+        return 'Lead level is high. Please seek medical attention and act on the guidance immediately.';
+      default:
+        return 'Complete the assessment to understand the exposure risk.';
+    }
+  }
+}

--- a/lib/services/feature_encoder.dart
+++ b/lib/services/feature_encoder.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show FlutterError, rootBundle;
+
+import '../models/lead_input.dart';
+import 'prediction_exception.dart';
+
+class FeatureEncoder {
+  FeatureEncoder._();
+
+  static final FeatureEncoder _instance = FeatureEncoder._();
+
+  factory FeatureEncoder() => _instance;
+
+  List<String>? _featureOrder;
+  Map<String, Map<String, double>>? _encodings;
+  List<double>? _means;
+  List<double>? _stds;
+  Future<void>? _loadingFuture;
+
+  Future<List<double>> encode(LeadInput input) async {
+    await _ensureLoaded();
+
+    final order = _featureOrder ?? input.values.keys.toList();
+    final encodings = _encodings;
+
+    if (encodings == null || encodings.isEmpty) {
+      throw PredictionException(
+        'Feature encodings were not found. Ensure assets/models/feature_metadata.json contains an "encodings" section.',
+      );
+    }
+
+    final features = <double>[];
+
+    for (final key in order) {
+      final rawValue = input.values[key];
+      if (rawValue == null) {
+        throw PredictionException('Missing value for "$key".');
+      }
+
+      final mapping = encodings[key];
+      if (mapping == null) {
+        throw PredictionException(
+          'No encoding defined for feature "$key". Update feature_metadata.json to match your preprocessing.',
+        );
+      }
+
+      final encoded = mapping[rawValue];
+      if (encoded == null) {
+        throw PredictionException(
+          'Value "$rawValue" is not mapped for feature "$key". Update feature_metadata.json accordingly.',
+        );
+      }
+
+      features.add(encoded);
+    }
+
+    if (_means != null && _stds != null &&
+        _means!.length == features.length &&
+        _stds!.length == features.length) {
+      for (var i = 0; i < features.length; i++) {
+        final std = _stds![i];
+        if (std == 0) continue;
+        features[i] = (features[i] - _means![i]) / std;
+      }
+    }
+
+    return features;
+  }
+
+  Future<void> _ensureLoaded() {
+    if (_featureOrder != null && _encodings != null) {
+      return Future.value();
+    }
+
+    return _loadingFuture ??= _loadMetadata();
+  }
+
+  Future<void> _loadMetadata() async {
+    try {
+      final jsonString = await rootBundle.loadString('models/feature_metadata.json');
+      final Map<String, dynamic> decoded = jsonDecode(jsonString) as Map<String, dynamic>;
+
+      final orderRaw = decoded['featureOrder'];
+      if (orderRaw is List) {
+        _featureOrder = orderRaw.map((e) => e.toString()).toList();
+      } else {
+        _featureOrder = LeadInput.empty().values.keys.toList();
+      }
+
+      final encodingsRaw = decoded['encodings'];
+      if (encodingsRaw is Map<String, dynamic>) {
+        _encodings = encodingsRaw.map((key, value) {
+          final valueMap = value as Map<String, dynamic>;
+          return MapEntry(
+            key,
+            valueMap.map((option, encoding) => MapEntry(option, (encoding as num).toDouble())),
+          );
+        });
+      }
+
+      final normalization = decoded['normalization'];
+      if (normalization is Map<String, dynamic>) {
+        final meanRaw = normalization['mean'];
+        final stdRaw = normalization['std'];
+        if (meanRaw is List && stdRaw is List && meanRaw.length == stdRaw.length) {
+          _means = meanRaw.map((value) => (value as num).toDouble()).toList();
+          _stds = stdRaw.map((value) => (value as num).toDouble()).toList();
+        }
+      }
+    } on FlutterError {
+      throw PredictionException(
+        'Feature metadata file not found. Add assets/models/feature_metadata.json generated from your training pipeline.',
+      );
+    } on FormatException catch (error) {
+      throw PredictionException('Feature metadata is not valid JSON: ${error.message}');
+    } catch (error) {
+      throw PredictionException('Unable to load feature metadata: $error');
+    } finally {
+      _loadingFuture = null;
+    }
+  }
+}

--- a/lib/services/prediction_exception.dart
+++ b/lib/services/prediction_exception.dart
@@ -1,0 +1,8 @@
+class PredictionException implements Exception {
+  final String message;
+
+  PredictionException(this.message);
+
+  @override
+  String toString() => 'PredictionException: $message';
+}

--- a/lib/services/prediction_service.dart
+++ b/lib/services/prediction_service.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/foundation.dart';
+import 'package:tflite_flutter/tflite_flutter.dart';
+
+import '../models/lead_input.dart';
+import '../models/prediction_result.dart';
+import 'feature_encoder.dart';
+import 'prediction_exception.dart';
+
+class PredictionService {
+  PredictionService._();
+
+  static final PredictionService _instance = PredictionService._();
+
+  factory PredictionService() => _instance;
+
+  Interpreter? _interpreter;
+
+  Future<PredictionResult> predict(LeadInput input) async {
+    if (!input.isComplete) {
+      throw PredictionException('Please complete all fields before calculating the prediction.');
+    }
+
+    final interpreter = await _loadInterpreter();
+    final features = await FeatureEncoder().encode(input);
+
+    final inputTensor = interpreter.getInputTensor(0);
+    final inputShape = inputTensor.shape;
+    final expectedFeatureLength = inputShape.isNotEmpty ? inputShape.last : features.length;
+
+    if (expectedFeatureLength != features.length) {
+      throw PredictionException(
+        'The model expects $expectedFeatureLength features but ${features.length} were provided. Update feature_metadata.json to match your training pipeline.',
+      );
+    }
+
+    final outputTensor = interpreter.getOutputTensor(0);
+    final outputShape = outputTensor.shape;
+
+    final inputBuffer = [features];
+    final outputBuffer = List.generate(
+      outputShape.isNotEmpty ? outputShape.first : 1,
+      (_) => List.filled(outputShape.length > 1 ? outputShape[1] : 1, 0.0),
+    );
+
+    interpreter.run(inputBuffer, outputBuffer);
+
+    final predictedValue = _extractFirstValue(outputBuffer);
+    final sanitizedValue = predictedValue.isFinite ? predictedValue : 0.0;
+    final roundedValue = double.parse(sanitizedValue.toStringAsFixed(2));
+
+    return PredictionResult(
+      predictedBll: roundedValue,
+      riskLevel: _determineRiskLevel(roundedValue),
+    );
+  }
+
+  Future<Interpreter> _loadInterpreter() async {
+    if (_interpreter != null) {
+      return _interpreter!;
+    }
+
+    try {
+      _interpreter = await Interpreter.fromAsset('models/lead_level_model.tflite');
+      return _interpreter!;
+    } on Exception catch (error) {
+      debugPrint('Failed to load interpreter: $error');
+      throw PredictionException(
+        'Unable to load the TensorFlow Lite model. Replace assets/models/lead_level_model.tflite with your trained model file.',
+      );
+    }
+  }
+
+  double _extractFirstValue(dynamic tensorOutput) {
+    if (tensorOutput is List && tensorOutput.isNotEmpty) {
+      return _extractFirstValue(tensorOutput.first);
+    }
+    if (tensorOutput is num) {
+      return tensorOutput.toDouble();
+    }
+    throw PredictionException('Unexpected model output format: ${tensorOutput.runtimeType}');
+  }
+
+  String _determineRiskLevel(double bll) {
+    if (bll < 5) {
+      return 'Low';
+    }
+    if (bll < 10) {
+      return 'Moderate';
+    }
+    return 'High';
+  }
+}

--- a/lib/services/suggestions_service.dart
+++ b/lib/services/suggestions_service.dart
@@ -1,0 +1,35 @@
+import '../models/prediction_result.dart';
+
+class SuggestionsService {
+  List<String> buildSuggestions(PredictionResult? result) {
+    if (result == null) {
+      return const [
+        'Complete the assessment to view tailored suggestions.',
+      ];
+    }
+
+    switch (result.riskLevel) {
+      case 'Low':
+        return const [
+          'Continue regular monitoring of potential lead sources at home.',
+          'Maintain a balanced diet rich in calcium and iron to block lead absorption.',
+          'Schedule periodic re-testing if there is ongoing exposure.',
+        ];
+      case 'Moderate':
+        return const [
+          'Increase cleaning frequency of floors and surfaces to remove lead dust.',
+          'Encourage hand-washing before meals and after outdoor play.',
+          'Use certified water filters and flush taps before use.',
+          'Consult a healthcare provider for targeted blood lead follow-up.',
+        ];
+      case 'High':
+      default:
+        return const [
+          'Seek immediate medical advice for chelation eligibility and follow-up testing.',
+          'Remove or isolate known lead sources such as peeling paint, contaminated soil, or lead-glazed utensils.',
+          'Provide iron, calcium, and vitamin C rich meals to reduce lead absorption.',
+          'Inform local public health authorities about potential community exposure.',
+        ];
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,19 @@
+name: lead_level_predictor
+description: A Flutter app to predict blood lead levels based on user inputs.
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.1.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.6
+  tflite_flutter: ^0.10.4
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/models/


### PR DESCRIPTION
## Summary
- automatically switch to the Results tab after a successful prediction so users see their blood lead estimate immediately
- update the input form to notify listeners when predictions complete and adjust the success snackbar messaging
- expand the README with concrete commands for dropping a trained TensorFlow Lite model and metadata into the Flutter project

## Testing
- not run (Flutter tooling is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d4ebbf3d5c832dad36d7c784214a54